### PR TITLE
Added missing require for the Chef::Provider::ArkBase

### DIFF
--- a/libraries/provider_ark_cherry_pick.rb
+++ b/libraries/provider_ark_cherry_pick.rb
@@ -20,6 +20,7 @@
 
 
 require 'chef/provider'
+require File.expand_path('provider_ark.rb',      File.dirname(__FILE__))
 
 class Chef
   class Provider


### PR DESCRIPTION
I was trying the LWRP and I got this error:

```
[Mon, 09 Apr 2012 23:39:13 -0700] DEBUG: NameError: uninitialized constant Chef::Provider::ArkBase
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/ark/libraries/provider_ark_cherry_pick.rb:26
```

I check the code and I realized that the rest of provider were requiring the local file `provider_ark.rb`, but not this one, so I guessed it was the problem and it works.

Now I have it working fine.
