### PR TITLE
path fixes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,5 @@
 
 default['ark']['apache_mirror'] = 'http://apache.mirrors.tds.net'
 default['ark']['prefix_root'] = "/usr/local"
-default['ark']['prefix_home'] = "share"
-default['ark']['prefix_install'] = "share"
-default['ark']['prefix_src'] = "src"
+default['ark']['prefix_bin'] = "/usr/local"
+default['ark']['prefix_home'] = "/usr/share"

--- a/libraries/provider_ark.rb
+++ b/libraries/provider_ark.rb
@@ -146,7 +146,7 @@ class Chef
           end
         end
         if new_resource.append_env_path
-          new_path = ::File.join(new_resource.path, 'bin')
+          new_path = ::File.join(new_resource.prefix_bin, 'bin')
           Chef::Log.debug("new_path is #{new_path}")
 
           path = "/etc/profile.d/#{new_resource.name}.sh"

--- a/libraries/resource_ark.rb
+++ b/libraries/resource_ark.rb
@@ -32,9 +32,11 @@ class Chef
         @append_env_path = false
         @strip_leading_dir = true
         @checksum = nil
-        @prefix_root = '/usr/local'
+        @prefix_root = nil
+        @prefix_bin = nil
+        @prefix_home = nil
         @home_dir = nil
-        @path = '/usr/local'
+        @path = nil
         @full_path = nil
         @has_binaries = []
         @release_file = ''
@@ -50,8 +52,8 @@ class Chef
         @provider = Chef::Provider::Ark
       end
 
-      attr_accessor :path, :release_file, :prefix_root, :home_dir
-      
+      attr_accessor :path, :release_file, :prefix_bin, :prefix_root, :home_dir
+
       def owner(arg=nil)
         set_or_return(
                       :owner,
@@ -81,7 +83,7 @@ class Chef
                       :kind_of => String)
       end
 
-      
+
       def append_env_path(arg=nil)
         set_or_return(
                       :append_env_path,
@@ -90,7 +92,7 @@ class Chef
                       )
       end
 
-      
+
       def checksum(arg=nil)
         set_or_return(
                       :checksum,
@@ -134,7 +136,7 @@ class Chef
         set_or_return(
                       :mode,
                       arg,
-                      :kind_of => Fixnum                     
+                      :kind_of => Fixnum
                       )
       end
 
@@ -142,11 +144,18 @@ class Chef
         set_or_return(
                       :prefix_root,
                       arg,
-                      :kind_of => String,
-                      :required => true
+                      :kind_of => String
                       )
       end
-      
+
+      def prefix_bin(arg=nil)
+        set_or_return(
+                      :prefix_bin,
+                      arg,
+                      :kind_of => String
+                      )
+      end
+
       def version(arg=nil)
         set_or_return(
                       :version,
@@ -155,7 +164,7 @@ class Chef
                       :required => true
                       )
       end
-      
+
       def home_dir(arg=nil)
         set_or_return(
                       :home_dir,


### PR DESCRIPTION
Hey Bryan,

I've looked into your cookbook and yeah it's awesome. In my opinion your logic with paths doesn't work quite good or isn't fully implemented yet... 
So I made some changes regarding path logic. Namely there's now choice between default recipe attributes and resource attributes.
For example, to get the root_prefix first we try attribute if it explicitly set in the resource block if not we try default value from run_context.node (say defined via node attributes).
What do think of it? Is it good to the way like this?
Also have look at one regex in the code...

Regards,
Denis
