### PR TITLE
Fix issue 6: ignore append_env_path on FreeBSD

### DIFF
--- a/files/default/tests/minitest/test/ark_install_test.rb
+++ b/files/default/tests/minitest/test/ark_install_test.rb
@@ -23,9 +23,11 @@ class TestArkInstall < MiniTest::Chef::TestCase
   end
 
   def test_append_env_path
-    bin_path = "/usr/local/tomcat-7.0.26/bin"
-    bin_path_present = !ENV['PATH'].scan(bin_path).empty?
-    assert bin_path_present
+    unless RUBY_PLATFORM =~ /freebsd/
+      bin_path = "/usr/local/tomcat-7.0.26/bin"
+      bin_path_present = !ENV['PATH'].scan(bin_path).empty?
+      assert bin_path_present
+    end
   end
   
   def test_owner

--- a/libraries/provider_ark.rb
+++ b/libraries/provider_ark.rb
@@ -317,6 +317,17 @@ class Chef
       end
 
       def append_to_env_path
+        if platform?("freebsd")
+          if new_resource.has_binaries.empty?
+            Chef::Log.warn "#{new_resource} specifies append_env_path but that is unimplemented on FreeBSD; " +
+                            "consider using has_binaries"
+          else
+            Chef::Log.info "#{new_resource} specifies both has_binaries and append_env_path; " +
+                            "the latter is a noop on FreeBSD."
+          end
+          return
+        end
+
         new_path = ::File.join(new_resource.path, 'bin')
         Chef::Log.debug("new_path is #{new_path}")
         path = "/etc/profile.d/#{new_resource.name}.sh"

--- a/libraries/provider_ark.rb
+++ b/libraries/provider_ark.rb
@@ -146,17 +146,6 @@ class Chef
           end
         end
         if new_resource.append_env_path
-          new_path = ::File.join(new_resource.path, 'bin')
-          Chef::Log.debug("new_path is #{new_path}")
-          path = "/etc/profile.d/#{new_resource.name}.sh"
-          f = Chef::Resource::File.new(path, run_context)
-          f.content <<-EOF
-          export PATH=$PATH:#{new_path}
-          EOF
-          f.mode 0755
-          f.owner 'root'
-          f.group 'root'
-          f.run_action(:create)
           append_to_env_path
         end
       end
@@ -328,6 +317,18 @@ class Chef
       end
 
       def append_to_env_path
+        new_path = ::File.join(new_resource.path, 'bin')
+        Chef::Log.debug("new_path is #{new_path}")
+        path = "/etc/profile.d/#{new_resource.name}.sh"
+        f = Chef::Resource::File.new(path, run_context)
+        f.content <<-EOF
+        export PATH=$PATH:#{new_path}
+        EOF
+        f.mode 0755
+        f.owner 'root'
+        f.group 'root'
+        f.run_action(:create)
+
         bin_path = ::File.join(new_resource.path, 'bin')
         unless ENV['PATH'].scan(bin_path).empty?
           ENV['PATH'] = ENV['PATH'] + ':' + bin_path


### PR DESCRIPTION
I have a failure on FreeBSD:

  1) Failure:
test_append_env_path(TestArkInstall) [/var/chef/minitest/ark-test/ark_install_test.rb:28]:
Failed assertion, no message given.

That's a given, since we don't touch the PATH.

The problem is that platform? seems to be unavailable in tests; we would need to do that in plain ruby. Ugh.
