### PR TITLE
Disable a Linux-specific test on FreeBSD.

### DIFF
--- a/files/default/tests/minitest/test/ark_install_with_make_test.rb
+++ b/files/default/tests/minitest/test/ark_install_with_make_test.rb
@@ -1,3 +1,5 @@
+unless RUBY_PLATFORM =~ /freebsd/
+
 class TestArkInstallWithMake < MiniTest::Chef::TestCase
 
   def path
@@ -27,5 +29,7 @@ class TestArkInstallWithMake < MiniTest::Chef::TestCase
   def test_bin_executable
     assert File.executable? "#{path}/haproxy"
   end
+
+end
 
 end

--- a/recipes/test.rb
+++ b/recipes/test.rb
@@ -67,7 +67,7 @@ ark "haproxy" do
   checksum 'ba0424bf7d23b3a607ee24bbb855bb0ea347d7ffde0bec0cb12a89623cbaf911'
   make_opts [ 'TARGET=linux26' ]
   action :install_with_make
-end
+end unless node.platform?("freebsd")
 
 ark "maven2" do
   url "http://apache.mirrors.tds.net/maven/binaries/apache-maven-2.2.1-bin.tar.gz"


### PR DESCRIPTION
Fixes #12, except tests don't pass on FreeBSD; they should still pass on Linux.
