### PR TITLE
[FIX] Removed stray `unless` in Chef::Provider::Ark#action_install_with_make

### DIFF
--- a/libraries/provider_ark.rb
+++ b/libraries/provider_ark.rb
@@ -102,7 +102,7 @@ class Chef
         b.cwd new_resource.path
         b.environment new_resource.environment
         b.code "make install"
-        b.run_action(:run) unless 
+        b.run_action(:run)
       end
 
       # needs a test, start here http://guide.python-distribute.org/quickstart.html


### PR DESCRIPTION
The current `ark` version fails with:

```
ruby -W /etc/vagrant-chef/chef-solo-2/cookbooks/ark/libraries/provider_ark.rb
/etc/vagrant-chef/chef-solo-2/cookbooks/ark/libraries/provider_ark.rb:106: syntax error, unexpected kEND
/etc/vagrant-chef/chef-solo-2/cookbooks/ark/libraries/provider_ark.rb:404: syntax error, unexpected $end, expecting kEND
```

This patch removes the stray `unless` modifier.
