### PR TITLE
Don't set owner, group, mode unless unpacking the archive

### DIFF
--- a/libraries/provider_ark.rb
+++ b/libraries/provider_ark.rb
@@ -53,7 +53,6 @@ class Chef
         set_paths
         action_download
         action_unpack
-        action_set_owner new_resource.path
         action_install_binaries
         action_link_paths
       end
@@ -158,7 +157,6 @@ class Chef
         set_put_paths
         action_download
         action_unpack
-        action_set_owner new_resource.path
       end
 
       def action_cherry_pick_contents(full_path)
@@ -185,6 +183,7 @@ class Chef
         cmd = expand_cmd
         unless unpacked? new_resource.path
           eval(cmd)
+          action_set_owner new_resource.path
           new_resource.updated_by_last_action(true)
         end
       end


### PR DESCRIPTION
I am using ark to install Tomcat (also derived from a @bryanwb cookbook), and I noticed that Tomcat was restarting every time I did a chef run.  The root cause was because of the recursive FileUtils.chown_R and FileUtils.chmod_R called unconditionally from action_set_owner(), which is called from action_install() and action_put().

Inside my exploded Tomcat, I have some config XML files and WAR files that do not have 755 permissions (which is what ark is recursively setting).  When chef runs, the ark recipe changes my war and config files to 755 and then when my template and remote_file resources run to set up XML and WAR files they change the permissions back.  This falsely triggers service tomcat to restart every chef run.

The way ark is now, the only permissions that will avoid this behavior is if every file under the exploded archive has user and group match the ark archive and has a 755 permission level.

I think a reasonable fix is to only change the permissions when unpacking.
